### PR TITLE
Initial TypeScript definition and Haxe extern generation

### DIFF
--- a/src/genjs/generator/hxextern/HxExternClassGenerator.hx
+++ b/src/genjs/generator/hxextern/HxExternClassGenerator.hx
@@ -1,0 +1,212 @@
+package genjs.generator.hxextern;
+
+import haxe.ds.Option;
+import haxe.macro.JSGenApi;
+import haxe.macro.Type;
+import genjs.processor.*;
+
+using tink.MacroApi;
+using haxe.io.Path;
+using haxe.macro.TypeTools;
+using StringTools;
+using genjs.template.CodeTools;
+
+class HxExternClassGenerator {
+
+	public static function generate(api:JSGenApi, c:ProcessedClass) {
+
+		function superClassName(c:ClassType) 
+			return switch c.superClass {
+				case null: null;
+				case {t: sc}:
+					var sc = ClassProcessor.process(api, sc.toString(), sc.get());
+					return sc.id.asAccessName(sc.externType);
+			}		
+		
+		if((c.constructor == null || c.constructor.code == null) && c.fields.length == 0)
+			return None;
+		if(c.type.isExtern)
+			return None;
+		
+		var filepath = c.id.asFilePath() + '.hx';
+		var name = c.type.name;
+		
+		switch (c.id) {
+			case "Type", "Reflect", "haxe.IMap", "js._Boot.HaxeError", "js.Boot", "Std":
+				return None;
+		}
+		
+		// temp?
+		if (StringTools.startsWith (c.id, "js.")) return None;
+		
+		var data = {};
+		// Reflect.setField(data, 'className', name);
+		// Reflect.setField(data, c.id.asTemplateHolder(), name);
+		// for(dependency in c.dependencies) switch dependency {
+		// 	case DType(TypeProcessor.process(api, _) => Some(PClass(c))):
+		// 		Reflect.setField(data, c.id.asTemplateHolder(), c.id.asAccessName(c.externType));
+			
+		// 	case DType(TypeProcessor.process(api, _) => Some(PEnum(e))): 
+		// 		Reflect.setField(data, e.id.asTemplateHolder(), e.id.asAccessName());
+				
+		// 	default:
+		// }
+		// HACK: Runtime type values from Std
+		// Reflect.setField(data, 'Date', 'Date');
+		// Reflect.setField(data, 'Int', '$$hxClasses["Int"]');
+		// Reflect.setField(data, 'Dynamic', '$$hxClasses["Dynamic"]');
+		// Reflect.setField(data, 'Float', '$$hxClasses["Float"]');
+		// Reflect.setField(data, 'Bool', '$$hxClasses["Bool"]');
+		// Reflect.setField(data, 'Class', '$$hxClasses["Class"]');
+		// Reflect.setField(data, 'Enum', '$$hxClasses["Enum"]');
+		// Reflect.setField(data, 'Void', '$$hxClasses["Void"]');
+		
+		var packageName = c.id.split (".").slice (0, -1).join (".");
+		var packageDecl = "package" + (packageName != "" ? " " + packageName : "") + ";";
+		
+		var imports = HxExternRequireGenerator.generate(api, filepath.directory(), c.dependencies);
+		
+		var require = '@:jsRequire("' + c.id.split (".").join ("/") + '", "default")';
+		//var classStart = "extern class " + c.id.split (".").pop () + (c.type.superClass != null ? " extends " + c.type.superClass.t.get ().name : "") + " {";
+		var className = c.id.split (".").pop ();
+		var superClassName = null;
+		var ignoreSuper = false;
+		
+		if (c.type.superClass != null) {
+			var type = c.type.superClass.t.get ();
+			// TODO: Fix for capitalized packages
+			var pack = "";
+			if (type.pack.length > 0) pack = type.pack.join (".");
+			if (pack == pack.toLowerCase ()) {
+				if (pack != "") superClassName = pack + "." + type.name;
+				else superClassName = type.name;
+			} else {
+				ignoreSuper = true;
+			}
+		}
+		
+		var classStart = "extern class " + className + (superClassName != null ? " extends " + superClassName : "") + " implements Dynamic {";
+		// var classStart = "extern class " + c.id.split (".").pop () + " extends Dynamic {";
+		
+		// var body = "function new ();";
+		var body = "";
+		
+		var hasField;
+		
+		hasField = function (name:String, superClass:haxe.macro.Ref<haxe.macro.ClassType>) {
+			if (ignoreSuper) return false;
+			if (superClass != null) {
+				var sc = superClass.get ();
+				var fields = sc.fields.get();
+				for (field in fields) {
+					if (field.name == name) return true;
+				}
+				if (sc.superClass == null) return false;
+				return hasField (name, sc.superClass.t);
+			}
+			return false;
+		}
+		
+		// var convertParams = function (field:haxe.macro.ClassField) {
+		// 	var params = "";
+		// 	if (field != null && field.type != null) {
+		// 		switch (field.type) {
+		// 			case TFun(args, _):
+		// 				for (arg in args) {
+		// 					if (params != "") params += ", ";
+		// 					params += (arg.opt ? "?" : "") + arg.name + ":" + "Dynamic"/*arg.t.toString ()*/;
+		// 				}
+		// 			default:
+		// 		}
+		// 	}
+		// 	return params;
+		// }
+		
+		var processField = function (field:haxe.macro.ClassField, isStatic:Bool) {
+			var fieldCode = "";
+			if (field != null && field.type != null) {
+				switch (field.type) {
+					case TFun(args, _):
+						var params = "";
+						var i = 0;
+						for (arg in args) {
+							if (params != "") params += ", ";
+							var name = (arg.name != "" && arg.name != null) ? arg.name : "a" + (++i);
+							params += (arg.opt ? "?" : "") + name + ":" + "Dynamic"/*arg.t.toString ()*/;
+						}
+						fieldCode = ((c.type.superClass != null && hasField(field.name, c.type.superClass.t)) ? "override " : "") + (isStatic? "static " : "") + "function " + field.name + "(" + params + ")" + (field.name != "new" ? ":Dynamic" : "") + ";";
+					case TInst(t, _):
+						fieldCode = (isStatic? "static " : "") + "var " + field.name + ":Dynamic;";
+					case TAbstract(t, _):
+						fieldCode = (isStatic? "static " : "") + "var " + field.name + ":Dynamic;";
+					default:
+				}
+			}
+			body += "\t" + fieldCode + "\n";
+		}
+		
+		if (c.constructor != null) processField (c.constructor.field, false);
+		for (field in c.fields) processField (field.field, field.isStatic);
+		
+		//var ctor = if (c.constructor != null) "function new(" + convertParams (c.constructor.field) + ");" else "";
+		
+		
+		// TODO: Add fields
+		
+		// var ctor = 'var $name = ' + switch c.constructor {
+		// 	case null | {template: null}: 'function(){}';
+		// 	case {template: template}: template.execute(data);
+		// }
+		
+		// var fields = [];
+		// for(field in c.fields.filter(function(f) return !f.isStatic)) {
+		// 	switch FieldGenerator.generate(api, field, data) {
+		// 		case Some(v): fields.push(v);
+		// 		case None:
+		// 	}
+		// }		
+		// var fields = '{\n' + fields.join(',\n').indent(1) + '\n}';
+		// // Statics
+		// var staticFunctions = [];
+		// var staticVariables = [];
+		// for(field in c.fields.filter(function(f) return f.isStatic)) {
+		// 	switch FieldGenerator.generate(api, field, data) {
+		// 		case Some(v): (field.isFunction ? staticFunctions : staticVariables).push(v);
+		// 		case None:
+		// 	}
+		// }
+		
+		// var statics = staticFunctions.join('\n') + '\n' + staticVariables.join('\n');
+		
+		// // Meta
+		// var cname = c.id.split('.').map(api.quoteString).join(',');
+		// var meta = ['$name.__name__ = [$cname];'];
+		
+		// switch c.type.interfaces {
+		// 	case null | []: // do nothing;
+		// 	case v:
+		// 		var inames = [for(i in v) ClassProcessor.process(api, i.t.toString(), i.t.get()).id.asAccessName()];
+		// 		meta.push('$name.__interfaces__ = [${inames.join(',')}];');
+		// }
+		
+		var classEnd = "}";
+		
+		
+		// var code = '';
+		// for(field in c.fields) if(field.template != null) code += '\n' + field.template.execute({});
+		// for(field in c.statics) if(field.template != null) code += '\n' + field.template.execute({});
+		// if(code != '') {
+		// 	trace(filepath);
+		// 	trace(code);
+		// }
+		return Some([
+			packageDecl,
+			imports,
+			require,
+			classStart,
+			// ctor,
+			body,
+			classEnd,
+		].join('\n\n'));
+	}
+}

--- a/src/genjs/generator/hxextern/HxExternClassGenerator.hx
+++ b/src/genjs/generator/hxextern/HxExternClassGenerator.hx
@@ -32,12 +32,13 @@ class HxExternClassGenerator {
 		var name = c.type.name;
 		
 		switch (c.id) {
-			case "Type", "Reflect", "haxe.IMap", "js._Boot.HaxeError", "js.Boot", "Std":
+			case "Type", "Reflect", "haxe.IMap", "js._Boot.HaxeError", "js.Boot", "Std", "HxOverrides":
 				return None;
 		}
 		
 		// temp?
 		if (StringTools.startsWith (c.id, "js.")) return None;
+		if (StringTools.startsWith (c.id, "haxe.")) return None;
 		
 		var data = {};
 		// Reflect.setField(data, 'className', name);

--- a/src/genjs/generator/hxextern/HxExternClassGenerator.hx
+++ b/src/genjs/generator/hxextern/HxExternClassGenerator.hx
@@ -32,13 +32,14 @@ class HxExternClassGenerator {
 		var name = c.type.name;
 		
 		switch (c.id) {
-			case "Type", "Reflect", "haxe.IMap", "js._Boot.HaxeError", "js.Boot", "Std", "HxOverrides":
+			case "Type", "Reflect", "haxe.IMap", "js._Boot.HaxeError", "js.Boot", "Std", "HxOverrides", "haxe.StackItem", "List", "StringTools":
 				return None;
 		}
 		
 		// temp?
 		if (StringTools.startsWith (c.id, "js.")) return None;
 		if (StringTools.startsWith (c.id, "haxe.")) return None;
+		if (StringTools.startsWith (filepath, "haxe/")) return None;
 		
 		var data = {};
 		// Reflect.setField(data, 'className', name);

--- a/src/genjs/generator/hxextern/HxExternEnumGenerator.hx
+++ b/src/genjs/generator/hxextern/HxExternEnumGenerator.hx
@@ -1,0 +1,49 @@
+package genjs.generator.hxextern;
+
+import haxe.ds.Option;
+import haxe.macro.JSGenApi;
+import genjs.processor.*;
+
+using tink.MacroApi;
+using haxe.io.Path;
+using StringTools;
+using genjs.template.CodeTools;
+
+class HxExternEnumGenerator {
+	public static function generate(api:JSGenApi, e:ProcessedEnum) {
+		
+		var filepath = e.id.asFilePath() + '.hx';
+		var name = e.type.name;
+		
+		// var data = {};
+		// Reflect.setField(data, 'enumName', name);
+		// Reflect.setField(data, name, name);
+		// for(dependency in e.dependencies) switch dependency {
+		// 	case DType(type): 
+		// 		var id:TypeID = type.getID();
+		// 		Reflect.setField(data, id.asTemplateHolder(), id.asVarSafeName() + '.default');
+		// 	default:
+		// }
+		
+		var packageName = e.id.split (".").slice (0, -1).join (".");
+		var packageDecl = "package" + (packageName != "" ? " " + packageName : "") + ";";
+		
+		var imports = HxExternRequireGenerator.generate(api, filepath.directory(), e.dependencies);
+		
+		// var enumStart = "extern enum " + e.id.split (".").pop () + " {";
+		var enumStart = "extern class " + e.id.split (".").pop () + " implements Dynamic {";
+		var enumEnd = "}";
+		
+		// var ename = e.id.split('.').map(api.quoteString).join(',');
+		// var constructs = e.type.names.map(api.quoteString).join(',');
+		// var ctor = 'var $name = $$hxClasses["${e.id}"] = { __ename__: [$ename], __constructs__: [$constructs] }';
+		// var fields = [for(c in e.constructors) c.template.execute(name)];
+		
+		return Some([
+			packageDecl,
+			imports,
+			enumStart,
+			enumEnd,
+		].join('\n\n'));
+	}
+}

--- a/src/genjs/generator/hxextern/HxExternFieldGenerator.hx
+++ b/src/genjs/generator/hxextern/HxExternFieldGenerator.hx
@@ -1,0 +1,18 @@
+package genjs.generator;
+
+import haxe.ds.Option;
+import haxe.macro.JSGenApi;
+import genjs.processor.*;
+
+using haxe.io.Path;
+using StringTools;
+
+class FieldGenerator {
+	public static function generate(api:JSGenApi, f:ProcessedField, data:Dynamic) {
+		if(f.template == null) return None;
+		return Some(switch f.isStatic {
+			case true: Reflect.field(data, 'className') + '.${f.field.name} = ' + f.template.execute(data);
+			case false: f.field.name + ': ' + f.template.execute(data);
+		});
+	}
+}

--- a/src/genjs/generator/hxextern/HxExternMainGenerator.hx
+++ b/src/genjs/generator/hxextern/HxExternMainGenerator.hx
@@ -1,0 +1,49 @@
+package genjs.generator;
+
+import haxe.ds.Option;
+import haxe.macro.JSGenApi;
+import genjs.processor.*;
+
+using tink.MacroApi;
+
+using Lambda;
+
+class MainGenerator {
+	public static function generate(api:JSGenApi, m:ProcessedMain, data:Dynamic) {
+		
+		
+		return switch m.template {
+			case null: None;
+			case template:
+				var requireStatements = RequireGenerator.generate(api, '', m.dependencies);
+				var main = template.execute(data) + ';';
+				var exposes = [];
+				for(name in m.exposes.keys()) {
+					var path = name.split('.');
+					
+					var current = [];
+					var access = switch m.exposes[name] {
+						case EClass(cls): cls.id.asAccessName();
+						case EClassField(cls, field): cls.id.asAccessName() + '.' + field.field.name;
+					}
+					
+					for(i in 0...path.length) {
+						current.push('["${path[i]}"]');
+						var export = 'exports' + current.join('');
+						
+						if(i == path.length - 1)
+							exposes.push('$export = $access');
+						else
+							exposes.push('$export = $export || {}');
+					}
+				}
+				// for(t in api.types) trace(t.getID());
+				Some([
+					'require("./Std")', // make sure those global stuff are initialized
+					requireStatements,
+					main,
+					exposes.join('\n'),
+				].join('\n'));
+		}
+	}
+}

--- a/src/genjs/generator/hxextern/HxExternRequireGenerator.hx
+++ b/src/genjs/generator/hxextern/HxExternRequireGenerator.hx
@@ -1,0 +1,60 @@
+package genjs.generator.hxextern;
+
+import haxe.macro.Type;
+import haxe.macro.JSGenApi;
+import genjs.processor.*;
+
+using haxe.io.Path;
+using tink.MacroApi;
+using StringTools;
+
+class HxExternRequireGenerator {
+	public static function generate(api:JSGenApi, currentPath:String, dependencies:Array<Dependency>) {
+		var code = [];
+		for(dep in dependencies) {
+			switch dep {
+				case DType(type):
+					switch TypeProcessor.flatten(type) {
+						case Some(FClass(id, cls)):
+							var cls = ClassProcessor.process(api, id, cls);
+							// TODO: Fix paths like "js._Boot.HaxeError"
+							var packageName = cls.id.split (".").slice (0, -1).join (".");
+							if (packageName == packageName.toLowerCase ())
+								switch cls.externType {
+									case None:
+										// var path = api.quoteString(prefix + id.asFilePath());
+										// code.push('function $varname() {return require($path);}');
+										if (id == "haxe.IMap") id = "haxe.Constraints.IMap";
+										code.push('import $id;');
+									case Require(p, false):
+										// var path = p[0];
+										// if(path.startsWith('.')) path = prefix + path;
+										// path = api.quoteString(path);
+										// code.push('function $varname() {return require($path);}');
+										code.push('import $id;');
+									case Require(p, true):
+										// var path = p[0];
+										// if(path.startsWith('.')) path = prefix + path;
+										// path = api.quoteString(path);
+										// code.push('function $varname() {return $$import(require($path));}');
+									case Native(_) | CoreApi | Global: 
+										// do nothing
+								}
+							
+						case Some(FEnum(id, enm)):
+							var packageName = id.split (".").slice (0, -1).join (".");
+							if (packageName == packageName.toLowerCase ())
+								code.push('import $id;');
+							
+						default:
+							continue;
+							
+					}
+					
+				case DStub(name):
+					continue;
+			}
+		}
+		return code.join('\n');
+	}
+}

--- a/src/genjs/generator/tsextern/TSExternClassGenerator.hx
+++ b/src/genjs/generator/tsextern/TSExternClassGenerator.hx
@@ -1,4 +1,4 @@
-package genjs.generator.extern;
+package genjs.generator.tsextern;
 
 import haxe.ds.Option;
 import haxe.macro.JSGenApi;
@@ -7,10 +7,11 @@ import genjs.processor.*;
 
 using tink.MacroApi;
 using haxe.io.Path;
+using haxe.macro.TypeTools;
 using StringTools;
 using genjs.template.CodeTools;
 
-class ExternClassGenerator {
+class TSExternClassGenerator {
 
 	public static function generate(api:JSGenApi, c:ProcessedClass) {
 
@@ -23,158 +24,174 @@ class ExternClassGenerator {
 			}		
 		
 		if((c.constructor == null || c.constructor.code == null) && c.fields.length == 0)
-			// HACK: we want to always generate a Std.js file so that we can require() it in the main entry point js file
-			return c.id == 'Std' ? Some('Object.defineProperty(exports, "__esModule", {value: true}); exports.default = {};') : None;
+			return None;
 		if(c.type.isExtern)
 			return None;
 		
-		var filepath = c.id.asFilePath() + '.js';
+		var filepath = c.id.asFilePath() + '.d.ts';
 		var name = c.type.name;
 		
+		switch (c.id) {
+			case "Type", "Reflect", "haxe.IMap", "js._Boot.HaxeError", "js.Boot", "Std":
+				return None;
+		}
+		
+		// temp?
+		if (StringTools.startsWith (c.id, "js.")) return None;
+		
 		var data = {};
-		Reflect.setField(data, 'className', name);
-		Reflect.setField(data, c.id.asTemplateHolder(), name);
-		for(dependency in c.dependencies) switch dependency {
-			case DType(TypeProcessor.process(api, _) => Some(PClass(c))):
-				Reflect.setField(data, c.id.asTemplateHolder(), c.id.asAccessName(c.externType));
+		// Reflect.setField(data, 'className', name);
+		// Reflect.setField(data, c.id.asTemplateHolder(), name);
+		// for(dependency in c.dependencies) switch dependency {
+		// 	case DType(TypeProcessor.process(api, _) => Some(PClass(c))):
+		// 		Reflect.setField(data, c.id.asTemplateHolder(), c.id.asAccessName(c.externType));
 			
-			case DType(TypeProcessor.process(api, _) => Some(PEnum(e))): 
-				Reflect.setField(data, e.id.asTemplateHolder(), e.id.asAccessName());
+		// 	case DType(TypeProcessor.process(api, _) => Some(PEnum(e))): 
+		// 		Reflect.setField(data, e.id.asTemplateHolder(), e.id.asAccessName());
 				
-			default:
-		}
+		// 	default:
+		// }
 		// HACK: Runtime type values from Std
-		Reflect.setField(data, 'Date', 'Date');
-		Reflect.setField(data, 'Int', '$$hxClasses["Int"]');
-		Reflect.setField(data, 'Dynamic', '$$hxClasses["Dynamic"]');
-		Reflect.setField(data, 'Float', '$$hxClasses["Float"]');
-		Reflect.setField(data, 'Bool', '$$hxClasses["Bool"]');
-		Reflect.setField(data, 'Class', '$$hxClasses["Class"]');
-		Reflect.setField(data, 'Enum', '$$hxClasses["Enum"]');
-		Reflect.setField(data, 'Void', '$$hxClasses["Void"]');
+		// Reflect.setField(data, 'Date', 'Date');
+		// Reflect.setField(data, 'Int', '$$hxClasses["Int"]');
+		// Reflect.setField(data, 'Dynamic', '$$hxClasses["Dynamic"]');
+		// Reflect.setField(data, 'Float', '$$hxClasses["Float"]');
+		// Reflect.setField(data, 'Bool', '$$hxClasses["Bool"]');
+		// Reflect.setField(data, 'Class', '$$hxClasses["Class"]');
+		// Reflect.setField(data, 'Enum', '$$hxClasses["Enum"]');
+		// Reflect.setField(data, 'Void', '$$hxClasses["Void"]');
 		
-		var requireStatements = RequireGenerator.generate(api, filepath.directory(), c.dependencies);
+		var packageName = c.id.split (".").slice (0, -1).join (".");
+		var packageDecl = packageName != "" ? "declare namespace " + packageName + " {" : "";
 		
-		var ctor = 'var $name = ' + switch c.constructor {
-			case null | {template: null}: 'function(){}';
-			case {template: template}: template.execute(data);
+		var imports = TSExternRequireGenerator.generate(api, filepath.directory(), c.dependencies);
+		
+		// var require = '@:jsRequire("' + c.id.split (".").join ("/") + '", "default")';
+		//var classStart = "extern class " + c.id.split (".").pop () + (c.type.superClass != null ? " extends " + c.type.superClass.t.get ().name : "") + " {";
+		var className = c.id.split (".").pop ();
+		var superClassName = null;
+		var ignoreSuper = false;
+		
+		if (c.type.superClass != null) {
+			var type = c.type.superClass.t.get ();
+			// TODO: Fix for capitalized packages
+			var pack = "";
+			if (type.pack.length > 0) pack = type.pack.join (".");
+			if (pack == pack.toLowerCase ()) {
+				if (pack != "") superClassName = pack + "." + type.name;
+				else superClassName = type.name;
+				superClassName = superClassName.replace('_', '_$$').replace('.', '_');
+			} else {
+				ignoreSuper = true;
+			}
 		}
-		#if (js_es==6)
-			switch ctor.indexOf('function(') {
-				case -1: throw 'assert';
-				case v: //DO NOT DO THIS AT HOME!!!!
-					ctor = {
-						var ctor = 'constructor' + ctor.substr(v + 'function'.length);
-						var cls = 
-							'class $name ' + switch superClassName(c.type) {
-								case null: '{\n${ctor.indent(1)}';
-								case v: 
-									var superCall = '$v.call(this';
-									switch ctor.indexOf(superCall) {
-										case -1: 
-											if (c.constructor == null)
-												ctor = '';
-											else {
-												if (c.type.superClass.t.get().constructor == null) {
-													switch ctor.indexOf('{') {
-														case -1: throw 'assert';
-														case v: 
-															ctor = [
-																ctor.substr(0, v+1),
-																"super()".indent(1),
-																ctor.substr(v + 1),
-															].join('\n');
-													}
-												}
-												else
-													c.constructor.field.pos.error('Could not find super call'); 
-											}
-										case v:
-										    var pretext = ctor.substr(0, v);
-											if (~/this[^a-zA-Z0-9_\$]/.match(pretext)) 
-												c.constructor.field.pos.warning('cannot access `this` before calling `super`');
-									}
-									ctor = 
-										ctor
-											.replace('$v.call(this,', 'super(')
-											.replace('$v.call(this', 'super(');
-									'extends $v {\n${ctor.indent(1)}';
-							}
-						cls + '\n';
-					}
-		  	}
-		#end
-		// Fields
-		#if (js_es >= 6) 
-			var statics = [];
-			ctor += [for (f in c.fields) 
-				if (f.template != null)
-					switch f.template.execute(data) {
-						case method if (method.startsWith('function(')):
-							(if (f.isStatic) 'static ' else '') 
-							+ f.field.name 
-							+ method.substr('function'.length);
-						case v:
-							if (f.isStatic) {
-								var name = f.field.name;
-								statics.push('var $name = $v;');
-								[
-									'static get $name() { return $name; }',
-									'static set $name(value) { $name = value; }',
-								].join('\n');
-							} 
-							else f.field.pos.error('field impossible to generate on ES6');
-							//c.type.pos.warning(v);
-							//v;
-					}
-			].join('\n').indent(1) + '\n}\n';
-			var statics = statics.join('\n');
-		#else 
-			var fields = [];
-			for(field in c.fields.filter(function(f) return !f.isStatic)) {
-				switch FieldGenerator.generate(api, field, data) {
-					case Some(v): fields.push(v);
-					case None:
+		
+		var classStart = "export class " + className + (superClassName != null ? " extends " + superClassName : "") + " {";
+		// var classStart = "extern class " + c.id.split (".").pop () + " extends Dynamic {";
+		
+		// var body = "function new ();";
+		var body = "";
+		
+		var hasField;
+		
+		hasField = function (name:String, superClass:haxe.macro.Ref<haxe.macro.ClassType>) {
+			if (ignoreSuper) return false;
+			if (superClass != null) {
+				var sc = superClass.get ();
+				var fields = sc.fields.get();
+				for (field in fields) {
+					if (field.name == name) return true;
 				}
-			}		
-			var fields = '{\n' + fields.join(',\n').indent(1) + '\n}';
-			// Statics
-			var staticFunctions = [];
-			var staticVariables = [];
-			for(field in c.fields.filter(function(f) return f.isStatic)) {
-				switch FieldGenerator.generate(api, field, data) {
-					case Some(v): (field.isFunction ? staticFunctions : staticVariables).push(v);
-					case None:
+				if (sc.superClass == null) return false;
+				return hasField (name, sc.superClass.t);
+			}
+			return false;
+		}
+		
+		// var convertParams = function (field:haxe.macro.ClassField) {
+		// 	var params = "";
+		// 	if (field != null && field.type != null) {
+		// 		switch (field.type) {
+		// 			case TFun(args, _):
+		// 				for (arg in args) {
+		// 					if (params != "") params += ", ";
+		// 					params += (arg.opt ? "?" : "") + arg.name + ":" + "Dynamic"/*arg.t.toString ()*/;
+		// 				}
+		// 			default:
+		// 		}
+		// 	}
+		// 	return params;
+		// }
+		
+		var processField = function (field:haxe.macro.ClassField, isStatic:Bool) {
+			var fieldCode = "";
+			if (field != null && field.type != null) {
+				switch (field.type) {
+					case TFun(args, _):
+						var params = "";
+						var i = 0;
+						for (arg in args) {
+							if (params != "") params += ", ";
+							var name = (arg.name != "" && arg.name != null) ? arg.name : "a" + (++i);
+							params += name + (arg.opt ? "?" : "") + ":" + "any"/*arg.t.toString ()*/;
+						}
+						// fieldCode = ((c.type.superClass != null && hasField(field.name, c.type.superClass.t)) ? "override " : "") + (isStatic? "static " : "") + (field.name == "new" ? "constructor" : field.name) + "(" + params + ")" + (field.name != "new" ? ":any" : "") + ";";
+						fieldCode = (isStatic? "static " : "") + (field.name == "new" ? "constructor" : field.name) + "(" + params + ")" + (field.name != "new" ? ":any" : "") + ";";
+					case TInst(t, _):
+						fieldCode = (isStatic? "static " : "") + field.name + ":any;";
+					case TAbstract(t, _):
+						fieldCode = (isStatic? "static " : "") + field.name + ":any;";
+					default:
 				}
 			}
-			
-			var statics = staticFunctions.join('\n') + '\n' + staticVariables.join('\n');
-		#end
-		// Meta
-		var cname = c.id.split('.').map(api.quoteString).join(',');
-		var meta = ['$name.__name__ = [$cname];'];
-		
-		switch c.type.interfaces {
-			case null | []: // do nothing;
-			case v:
-				var inames = [for(i in v) ClassProcessor.process(api, i.t.toString(), i.t.get()).id.asAccessName()];
-				meta.push('$name.__interfaces__ = [${inames.join(',')}];');
+			body += "\t" + fieldCode + "\n";
 		}
 		
-		#if (js_es < 6)
-		switch superClassName(c.type) {
-			case null:
-				meta.push('$name.prototype = $fields;');
-			case scname:
-				meta.push('$name.__super__ = $scname;');
-				meta.push('$name.prototype = $$extend($scname.prototype, $fields);');
-		}
-		#end
-		meta.push('$name.prototype.__class__ = $$hxClasses["${c.id}"] = $name;');
-		// __init__
-		var init = 
-			if(c.init != null) c.init.template.execute(data) + ';';
-			else '';
+		if (c.constructor != null) processField (c.constructor.field, false);
+		for (field in c.fields) processField (field.field, field.isStatic);
+		
+		//var ctor = if (c.constructor != null) "function new(" + convertParams (c.constructor.field) + ");" else "";
+		
+		
+		// TODO: Add fields
+		
+		// var ctor = 'var $name = ' + switch c.constructor {
+		// 	case null | {template: null}: 'function(){}';
+		// 	case {template: template}: template.execute(data);
+		// }
+		
+		// var fields = [];
+		// for(field in c.fields.filter(function(f) return !f.isStatic)) {
+		// 	switch FieldGenerator.generate(api, field, data) {
+		// 		case Some(v): fields.push(v);
+		// 		case None:
+		// 	}
+		// }		
+		// var fields = '{\n' + fields.join(',\n').indent(1) + '\n}';
+		// // Statics
+		// var staticFunctions = [];
+		// var staticVariables = [];
+		// for(field in c.fields.filter(function(f) return f.isStatic)) {
+		// 	switch FieldGenerator.generate(api, field, data) {
+		// 		case Some(v): (field.isFunction ? staticFunctions : staticVariables).push(v);
+		// 		case None:
+		// 	}
+		// }
+		
+		// var statics = staticFunctions.join('\n') + '\n' + staticVariables.join('\n');
+		
+		// // Meta
+		// var cname = c.id.split('.').map(api.quoteString).join(',');
+		// var meta = ['$name.__name__ = [$cname];'];
+		
+		// switch c.type.interfaces {
+		// 	case null | []: // do nothing;
+		// 	case v:
+		// 		var inames = [for(i in v) ClassProcessor.process(api, i.t.toString(), i.t.get()).id.asAccessName()];
+		// 		meta.push('$name.__interfaces__ = [${inames.join(',')}];');
+		// }
+		
+		var classEnd = "}\n\n" + (packageDecl != "" ? "}\n\nexport default " + packageName + "." + className : "export default " + className) + ";";
 		
 		
 		// var code = '';
@@ -185,22 +202,13 @@ class ExternClassGenerator {
 		// 	trace(code);
 		// }
 		return Some([
-			'// Class: ${c.id}',
-			'var $$global = typeof window != "undefined" ? window : typeof global != "undefined" ? global : typeof self != "undefined" ? self : this',
-			'$$global.Object.defineProperty(exports, "__esModule", {value: true});',
-			'var __map_reserved = {};', // TODO: add only if needed
-			'// Imports',
-			requireStatements,
-			'// Constructor',
-			ctor,
-			'// Meta',
-			meta.join('\n'),
-			'// Init',
-			init,
-			'// Statics',
-			statics,
-			'// Export',
-			'exports.default = $name;',
+			imports,
+			packageDecl,
+			// require,
+			classStart,
+			// ctor,
+			body,
+			classEnd,
 		].join('\n\n'));
 	}
 }

--- a/src/genjs/generator/tsextern/TSExternClassGenerator.hx
+++ b/src/genjs/generator/tsextern/TSExternClassGenerator.hx
@@ -1,0 +1,206 @@
+package genjs.generator.extern;
+
+import haxe.ds.Option;
+import haxe.macro.JSGenApi;
+import haxe.macro.Type;
+import genjs.processor.*;
+
+using tink.MacroApi;
+using haxe.io.Path;
+using StringTools;
+using genjs.template.CodeTools;
+
+class ExternClassGenerator {
+
+	public static function generate(api:JSGenApi, c:ProcessedClass) {
+
+		function superClassName(c:ClassType) 
+			return switch c.superClass {
+				case null: null;
+				case {t: sc}:
+					var sc = ClassProcessor.process(api, sc.toString(), sc.get());
+					return sc.id.asAccessName(sc.externType);
+			}		
+		
+		if((c.constructor == null || c.constructor.code == null) && c.fields.length == 0)
+			// HACK: we want to always generate a Std.js file so that we can require() it in the main entry point js file
+			return c.id == 'Std' ? Some('Object.defineProperty(exports, "__esModule", {value: true}); exports.default = {};') : None;
+		if(c.type.isExtern)
+			return None;
+		
+		var filepath = c.id.asFilePath() + '.js';
+		var name = c.type.name;
+		
+		var data = {};
+		Reflect.setField(data, 'className', name);
+		Reflect.setField(data, c.id.asTemplateHolder(), name);
+		for(dependency in c.dependencies) switch dependency {
+			case DType(TypeProcessor.process(api, _) => Some(PClass(c))):
+				Reflect.setField(data, c.id.asTemplateHolder(), c.id.asAccessName(c.externType));
+			
+			case DType(TypeProcessor.process(api, _) => Some(PEnum(e))): 
+				Reflect.setField(data, e.id.asTemplateHolder(), e.id.asAccessName());
+				
+			default:
+		}
+		// HACK: Runtime type values from Std
+		Reflect.setField(data, 'Date', 'Date');
+		Reflect.setField(data, 'Int', '$$hxClasses["Int"]');
+		Reflect.setField(data, 'Dynamic', '$$hxClasses["Dynamic"]');
+		Reflect.setField(data, 'Float', '$$hxClasses["Float"]');
+		Reflect.setField(data, 'Bool', '$$hxClasses["Bool"]');
+		Reflect.setField(data, 'Class', '$$hxClasses["Class"]');
+		Reflect.setField(data, 'Enum', '$$hxClasses["Enum"]');
+		Reflect.setField(data, 'Void', '$$hxClasses["Void"]');
+		
+		var requireStatements = RequireGenerator.generate(api, filepath.directory(), c.dependencies);
+		
+		var ctor = 'var $name = ' + switch c.constructor {
+			case null | {template: null}: 'function(){}';
+			case {template: template}: template.execute(data);
+		}
+		#if (js_es==6)
+			switch ctor.indexOf('function(') {
+				case -1: throw 'assert';
+				case v: //DO NOT DO THIS AT HOME!!!!
+					ctor = {
+						var ctor = 'constructor' + ctor.substr(v + 'function'.length);
+						var cls = 
+							'class $name ' + switch superClassName(c.type) {
+								case null: '{\n${ctor.indent(1)}';
+								case v: 
+									var superCall = '$v.call(this';
+									switch ctor.indexOf(superCall) {
+										case -1: 
+											if (c.constructor == null)
+												ctor = '';
+											else {
+												if (c.type.superClass.t.get().constructor == null) {
+													switch ctor.indexOf('{') {
+														case -1: throw 'assert';
+														case v: 
+															ctor = [
+																ctor.substr(0, v+1),
+																"super()".indent(1),
+																ctor.substr(v + 1),
+															].join('\n');
+													}
+												}
+												else
+													c.constructor.field.pos.error('Could not find super call'); 
+											}
+										case v:
+										    var pretext = ctor.substr(0, v);
+											if (~/this[^a-zA-Z0-9_\$]/.match(pretext)) 
+												c.constructor.field.pos.warning('cannot access `this` before calling `super`');
+									}
+									ctor = 
+										ctor
+											.replace('$v.call(this,', 'super(')
+											.replace('$v.call(this', 'super(');
+									'extends $v {\n${ctor.indent(1)}';
+							}
+						cls + '\n';
+					}
+		  	}
+		#end
+		// Fields
+		#if (js_es >= 6) 
+			var statics = [];
+			ctor += [for (f in c.fields) 
+				if (f.template != null)
+					switch f.template.execute(data) {
+						case method if (method.startsWith('function(')):
+							(if (f.isStatic) 'static ' else '') 
+							+ f.field.name 
+							+ method.substr('function'.length);
+						case v:
+							if (f.isStatic) {
+								var name = f.field.name;
+								statics.push('var $name = $v;');
+								[
+									'static get $name() { return $name; }',
+									'static set $name(value) { $name = value; }',
+								].join('\n');
+							} 
+							else f.field.pos.error('field impossible to generate on ES6');
+							//c.type.pos.warning(v);
+							//v;
+					}
+			].join('\n').indent(1) + '\n}\n';
+			var statics = statics.join('\n');
+		#else 
+			var fields = [];
+			for(field in c.fields.filter(function(f) return !f.isStatic)) {
+				switch FieldGenerator.generate(api, field, data) {
+					case Some(v): fields.push(v);
+					case None:
+				}
+			}		
+			var fields = '{\n' + fields.join(',\n').indent(1) + '\n}';
+			// Statics
+			var staticFunctions = [];
+			var staticVariables = [];
+			for(field in c.fields.filter(function(f) return f.isStatic)) {
+				switch FieldGenerator.generate(api, field, data) {
+					case Some(v): (field.isFunction ? staticFunctions : staticVariables).push(v);
+					case None:
+				}
+			}
+			
+			var statics = staticFunctions.join('\n') + '\n' + staticVariables.join('\n');
+		#end
+		// Meta
+		var cname = c.id.split('.').map(api.quoteString).join(',');
+		var meta = ['$name.__name__ = [$cname];'];
+		
+		switch c.type.interfaces {
+			case null | []: // do nothing;
+			case v:
+				var inames = [for(i in v) ClassProcessor.process(api, i.t.toString(), i.t.get()).id.asAccessName()];
+				meta.push('$name.__interfaces__ = [${inames.join(',')}];');
+		}
+		
+		#if (js_es < 6)
+		switch superClassName(c.type) {
+			case null:
+				meta.push('$name.prototype = $fields;');
+			case scname:
+				meta.push('$name.__super__ = $scname;');
+				meta.push('$name.prototype = $$extend($scname.prototype, $fields);');
+		}
+		#end
+		meta.push('$name.prototype.__class__ = $$hxClasses["${c.id}"] = $name;');
+		// __init__
+		var init = 
+			if(c.init != null) c.init.template.execute(data) + ';';
+			else '';
+		
+		
+		// var code = '';
+		// for(field in c.fields) if(field.template != null) code += '\n' + field.template.execute({});
+		// for(field in c.statics) if(field.template != null) code += '\n' + field.template.execute({});
+		// if(code != '') {
+		// 	trace(filepath);
+		// 	trace(code);
+		// }
+		return Some([
+			'// Class: ${c.id}',
+			'var $$global = typeof window != "undefined" ? window : typeof global != "undefined" ? global : typeof self != "undefined" ? self : this',
+			'$$global.Object.defineProperty(exports, "__esModule", {value: true});',
+			'var __map_reserved = {};', // TODO: add only if needed
+			'// Imports',
+			requireStatements,
+			'// Constructor',
+			ctor,
+			'// Meta',
+			meta.join('\n'),
+			'// Init',
+			init,
+			'// Statics',
+			statics,
+			'// Export',
+			'exports.default = $name;',
+		].join('\n\n'));
+	}
+}

--- a/src/genjs/generator/tsextern/TSExternEnumGenerator.hx
+++ b/src/genjs/generator/tsextern/TSExternEnumGenerator.hx
@@ -1,4 +1,4 @@
-package genjs.generator;
+package genjs.generator.tsextern;
 
 import haxe.ds.Option;
 import haxe.macro.JSGenApi;
@@ -9,38 +9,43 @@ using haxe.io.Path;
 using StringTools;
 using genjs.template.CodeTools;
 
-class EnumGenerator {
+class TSExternEnumGenerator {
 	public static function generate(api:JSGenApi, e:ProcessedEnum) {
 		
-		var filepath = e.id.asFilePath() + '.js';
+		var filepath = e.id.asFilePath() + '.d.ts';
 		var name = e.type.name;
 		
-		var data = {};
-		Reflect.setField(data, 'enumName', name);
-		Reflect.setField(data, name, name);
-		for(dependency in e.dependencies) switch dependency {
-			case DType(type): 
-				var id:TypeID = type.getID();
-				Reflect.setField(data, id.asTemplateHolder(), id.asVarSafeName() + '.default');
-			default:
-		}
-		var requireStatements = RequireGenerator.generate(api, filepath.directory(), e.dependencies);
+		// var data = {};
+		// Reflect.setField(data, 'enumName', name);
+		// Reflect.setField(data, name, name);
+		// for(dependency in e.dependencies) switch dependency {
+		// 	case DType(type): 
+		// 		var id:TypeID = type.getID();
+		// 		Reflect.setField(data, id.asTemplateHolder(), id.asVarSafeName() + '.default');
+		// 	default:
+		// }
 		
-		var ename = e.id.split('.').map(api.quoteString).join(',');
-		var constructs = e.type.names.map(api.quoteString).join(',');
-		var ctor = 'var $name = $$hxClasses["${e.id}"] = { __ename__: [$ename], __constructs__: [$constructs] }';
-		var fields = [for(c in e.constructors) c.template.execute(name)];
+		var packageName = e.id.split (".").slice (0, -1).join (".");
+		var packageDecl = packageName != "" ? "declare namespace " + packageName + " {" : "";
+		
+		var imports = TSExternRequireGenerator.generate(api, filepath.directory(), e.dependencies);
+		
+		// var enumStart = "extern enum " + e.id.split (".").pop () + " {";
+		var enumName = e.id.split (".").pop ();
+		var enumStart = "export enum " + e.id.split (".").pop () + " {";
+		// var enumEnd = "}\n\n" + (packageDecl != "" ? "}\n\n" : "") + "export default " + e.id.split (".").pop () + ";";
+		var enumEnd = "}\n\n" + (packageDecl != "" ? "}\n\nexport default " + packageName + "." + enumName : "export default " + enumName) + ";";
+		
+		// var ename = e.id.split('.').map(api.quoteString).join(',');
+		// var constructs = e.type.names.map(api.quoteString).join(',');
+		// var ctor = 'var $name = $$hxClasses["${e.id}"] = { __ename__: [$ename], __constructs__: [$constructs] }';
+		// var fields = [for(c in e.constructors) c.template.execute(name)];
 		
 		return Some([
-			'// Enum: ${e.id}',
-			'var $$global = typeof window != "undefined" ? window : typeof global != "undefined" ? global : typeof self != "undefined" ? self : this',
-			'$$global.Object.defineProperty(exports, "__esModule", {value: true});',
-			'// Imports',
-			requireStatements,
-			'// Definition',
-			ctor,
-			fields.join('\n'),
-			'exports.default = $name;',
+			imports,
+			packageDecl,
+			enumStart,
+			enumEnd,
 		].join('\n\n'));
 	}
 }

--- a/src/genjs/generator/tsextern/TSExternEnumGenerator.hx
+++ b/src/genjs/generator/tsextern/TSExternEnumGenerator.hx
@@ -1,0 +1,46 @@
+package genjs.generator;
+
+import haxe.ds.Option;
+import haxe.macro.JSGenApi;
+import genjs.processor.*;
+
+using tink.MacroApi;
+using haxe.io.Path;
+using StringTools;
+using genjs.template.CodeTools;
+
+class EnumGenerator {
+	public static function generate(api:JSGenApi, e:ProcessedEnum) {
+		
+		var filepath = e.id.asFilePath() + '.js';
+		var name = e.type.name;
+		
+		var data = {};
+		Reflect.setField(data, 'enumName', name);
+		Reflect.setField(data, name, name);
+		for(dependency in e.dependencies) switch dependency {
+			case DType(type): 
+				var id:TypeID = type.getID();
+				Reflect.setField(data, id.asTemplateHolder(), id.asVarSafeName() + '.default');
+			default:
+		}
+		var requireStatements = RequireGenerator.generate(api, filepath.directory(), e.dependencies);
+		
+		var ename = e.id.split('.').map(api.quoteString).join(',');
+		var constructs = e.type.names.map(api.quoteString).join(',');
+		var ctor = 'var $name = $$hxClasses["${e.id}"] = { __ename__: [$ename], __constructs__: [$constructs] }';
+		var fields = [for(c in e.constructors) c.template.execute(name)];
+		
+		return Some([
+			'// Enum: ${e.id}',
+			'var $$global = typeof window != "undefined" ? window : typeof global != "undefined" ? global : typeof self != "undefined" ? self : this',
+			'$$global.Object.defineProperty(exports, "__esModule", {value: true});',
+			'// Imports',
+			requireStatements,
+			'// Definition',
+			ctor,
+			fields.join('\n'),
+			'exports.default = $name;',
+		].join('\n\n'));
+	}
+}

--- a/src/genjs/generator/tsextern/TSExternFieldGenerator.hx
+++ b/src/genjs/generator/tsextern/TSExternFieldGenerator.hx
@@ -1,0 +1,18 @@
+package genjs.generator;
+
+import haxe.ds.Option;
+import haxe.macro.JSGenApi;
+import genjs.processor.*;
+
+using haxe.io.Path;
+using StringTools;
+
+class FieldGenerator {
+	public static function generate(api:JSGenApi, f:ProcessedField, data:Dynamic) {
+		if(f.template == null) return None;
+		return Some(switch f.isStatic {
+			case true: Reflect.field(data, 'className') + '.${f.field.name} = ' + f.template.execute(data);
+			case false: f.field.name + ': ' + f.template.execute(data);
+		});
+	}
+}

--- a/src/genjs/generator/tsextern/TSExternMainGenerator.hx
+++ b/src/genjs/generator/tsextern/TSExternMainGenerator.hx
@@ -1,0 +1,49 @@
+package genjs.generator;
+
+import haxe.ds.Option;
+import haxe.macro.JSGenApi;
+import genjs.processor.*;
+
+using tink.MacroApi;
+
+using Lambda;
+
+class MainGenerator {
+	public static function generate(api:JSGenApi, m:ProcessedMain, data:Dynamic) {
+		
+		
+		return switch m.template {
+			case null: None;
+			case template:
+				var requireStatements = RequireGenerator.generate(api, '', m.dependencies);
+				var main = template.execute(data) + ';';
+				var exposes = [];
+				for(name in m.exposes.keys()) {
+					var path = name.split('.');
+					
+					var current = [];
+					var access = switch m.exposes[name] {
+						case EClass(cls): cls.id.asAccessName();
+						case EClassField(cls, field): cls.id.asAccessName() + '.' + field.field.name;
+					}
+					
+					for(i in 0...path.length) {
+						current.push('["${path[i]}"]');
+						var export = 'exports' + current.join('');
+						
+						if(i == path.length - 1)
+							exposes.push('$export = $access');
+						else
+							exposes.push('$export = $export || {}');
+					}
+				}
+				// for(t in api.types) trace(t.getID());
+				Some([
+					'require("./Std")', // make sure those global stuff are initialized
+					requireStatements,
+					main,
+					exposes.join('\n'),
+				].join('\n'));
+		}
+	}
+}

--- a/src/genjs/generator/tsextern/TSExternRequireGenerator.hx
+++ b/src/genjs/generator/tsextern/TSExternRequireGenerator.hx
@@ -1,4 +1,4 @@
-package genjs.generator;
+package genjs.generator.tsextern;
 
 import haxe.macro.Type;
 import haxe.macro.JSGenApi;
@@ -8,7 +8,7 @@ using haxe.io.Path;
 using tink.MacroApi;
 using StringTools;
 
-class RequireGenerator {
+class TSExternRequireGenerator {
 	public static function generate(api:JSGenApi, currentPath:String, dependencies:Array<Dependency>) {
 		var prefix = './';
 		if(currentPath != '')
@@ -25,17 +25,17 @@ class RequireGenerator {
 							switch cls.externType {
 								case None:
 									var path = api.quoteString(prefix + id.asFilePath());
-									code.push('function $varname() {return require($path);}');
+									code.push('import $varname from $path;');
 								case Require(p, false):
 									var path = p[0];
 									if(path.startsWith('.')) path = prefix + path;
 									path = api.quoteString(path);
-									code.push('function $varname() {return require($path);}');
+									code.push('import $varname from $path;');
 								case Require(p, true):
 									var path = p[0];
 									if(path.startsWith('.')) path = prefix + path;
 									path = api.quoteString(path);
-									code.push('function $varname() {return $$import(require($path));}');
+									code.push('import $varname from $path;');
 								case Native(_) | CoreApi | Global: 
 									// do nothing
 							}
@@ -44,7 +44,7 @@ class RequireGenerator {
 						case Some(FEnum(id, enm)):
 							var path = api.quoteString(prefix + id.asFilePath());
 							var varname = id.asVarSafeName();
-							code.push('function $varname() {return require($path);}');
+							code.push('import $varname from $path;');
 							
 						default:
 							continue;
@@ -52,8 +52,8 @@ class RequireGenerator {
 					}
 					
 				case DStub(name):
-					var path = api.quoteString(prefix + name + '_stub');
-					code.push('var $$$name = require($path).default;');
+					//var path = api.quoteString(prefix + name + '_stub');
+					//code.push('var $$$name = require($path).default;');
 			}
 		}
 		return code.join('\n');

--- a/src/genjs/generator/tsextern/TSExternRequireGenerator.hx
+++ b/src/genjs/generator/tsextern/TSExternRequireGenerator.hx
@@ -1,0 +1,61 @@
+package genjs.generator;
+
+import haxe.macro.Type;
+import haxe.macro.JSGenApi;
+import genjs.processor.*;
+
+using haxe.io.Path;
+using tink.MacroApi;
+using StringTools;
+
+class RequireGenerator {
+	public static function generate(api:JSGenApi, currentPath:String, dependencies:Array<Dependency>) {
+		var prefix = './';
+		if(currentPath != '')
+			prefix += [for(i in 0...currentPath.split('/').length) '..'].join('/') + '/';
+			
+		var code = [];
+		for(dep in dependencies) {
+			switch dep {
+				case DType(type):
+					switch TypeProcessor.flatten(type) {
+						case Some(FClass(id, cls)):
+							var cls = ClassProcessor.process(api, id, cls);
+							var varname = id.asVarSafeName();
+							switch cls.externType {
+								case None:
+									var path = api.quoteString(prefix + id.asFilePath());
+									code.push('function $varname() {return require($path);}');
+								case Require(p, false):
+									var path = p[0];
+									if(path.startsWith('.')) path = prefix + path;
+									path = api.quoteString(path);
+									code.push('function $varname() {return require($path);}');
+								case Require(p, true):
+									var path = p[0];
+									if(path.startsWith('.')) path = prefix + path;
+									path = api.quoteString(path);
+									code.push('function $varname() {return $$import(require($path));}');
+								case Native(_) | CoreApi | Global: 
+									// do nothing
+							}
+							varname = id.asVarSafeName();
+							
+						case Some(FEnum(id, enm)):
+							var path = api.quoteString(prefix + id.asFilePath());
+							var varname = id.asVarSafeName();
+							code.push('function $varname() {return require($path);}');
+							
+						default:
+							continue;
+							
+					}
+					
+				case DStub(name):
+					var path = api.quoteString(prefix + name + '_stub');
+					code.push('var $$$name = require($path).default;');
+			}
+		}
+		return code.join('\n');
+	}
+}


### PR DESCRIPTION
I am using hxgenjs to output content from OpenFL, but I want to be able to use the content again from either TypeScript, or from Haxe. It may sound odd to use Haxe-generated code from Haxe again, but I think there are some interesting workflows this can enable.

Both are enabled using `-Dtsextern` or `-Dhxextern`, respectively, and are both rough. They are quality enough that I can compile code, but not to fully preserve all the correct types. I see this as a step forward in this direction. The initial results are enabling OpenFL on NPM: https://www.npmjs.com/package/openfl