### PR TITLE
Refine abstract statics check

### DIFF
--- a/src/genjs/processor/TypeProcessor.hx
+++ b/src/genjs/processor/TypeProcessor.hx
@@ -30,6 +30,15 @@ class TypeProcessor {
 				None;
 		}
 	}
+
+	static function shouldGenerateAbstract(cls) {
+		return cls.get().statics.get().filter(function (field)
+			return switch field.expr() {
+				case null: false;
+				case e: true;
+			}
+		).length > 0;
+	}
 	
 	public static function flatten(type:Type) {
 		return switch type {
@@ -37,8 +46,8 @@ class TypeProcessor {
 				None;
 			case TAbstract(_.get().impl => null, _):
 				None;
-			case TAbstract(_.get().impl => cls, _) 
-				if(cls.get().statics.get().length == 0): None;
+			case TAbstract(_.get().impl => cls, _) if(!shouldGenerateAbstract(cls)):
+				None;
 			case TInst(cls, _) | TAbstract(_.get().impl => cls, _):
 				Some(FClass(cls.toString(), cls.get()));
 			case TEnum(enm, _):

--- a/tests/abstract/src/Main.hx
+++ b/tests/abstract/src/Main.hx
@@ -5,6 +5,9 @@ import tink.unit.Assert.*;
 import tink.testrunner.*;
 import sys.FileSystem;
 
+// This abstract has getters/setters
+import tink.core.Ref;
+
 @:asserts
 class Main {
 	static function main() {
@@ -25,6 +28,10 @@ class Main {
 
 	public function shouldNotExist() {
 		return assert(!FileSystem.exists('bin/_Main/B_Impl_.js'));
+	}
+
+	public function refShouldNotBeGenerated() {
+		return assert(!FileSystem.exists('bin/tink/core/_Ref/Ref_Impl_.js'));
 	}
 }
 


### PR DESCRIPTION
This closes #18 again, sorry :) Some abstracts have statics, but their code equals null which means they're never generated (and so there's no use in generating the file either):
https://github.com/kevinresol/hxgenjs/blob/c3f831c00597d73ecf6ef7b133f1e8694a638c99/src/genjs/processor/ClassProcessor.hx#L84
https://github.com/kevinresol/hxgenjs/blob/c3f831c00597d73ecf6ef7b133f1e8694a638c99/src/genjs/generator/FieldGenerator.hx#L13