### PR TITLE
Handle native externType

### DIFF
--- a/src/genjs/processor/TypeID.hx
+++ b/src/genjs/processor/TypeID.hx
@@ -13,6 +13,8 @@ abstract TypeID(String) from String to String {
 	
 	public inline function asAccessName(?externType:ExternType)
 		return switch externType {
+			case Native(_):
+				this;
 			case null | None | Require([_], true):
 				'(' + asVarSafeName() + '()' + '.default' + ')';
 			case Require([_], false):


### PR DESCRIPTION
This fixes the externs with @:native.. for example in this case:
```
@:native("PIXI.Rectangle")
extern class Rectangle extends Shape {
```
previously the generated js was PIXI_Rectangle..., now with this fix it generates PIXI.Rectangle.