### PR TITLE
Fixes

### DIFF
--- a/src/genjs/Generator.hx
+++ b/src/genjs/Generator.hx
@@ -69,7 +69,10 @@ class Generator {
 	#if macro
 	public static function use() {
 		if (!Context.defined('js')) return;
+		
+		#if (haxe_ver < 4)
 		Context.onMacroContextReused(function() return false);
+		#end
 		
 		// WORKAROUND: https://github.com/HaxeFoundation/haxe/issues/6539
 		var folder = directory(Compiler.getOutput());

--- a/src/genjs/generator/EnumGenerator.hx
+++ b/src/genjs/generator/EnumGenerator.hx
@@ -33,9 +33,13 @@ class EnumGenerator implements IEnumGenerator {
 		
 		var ename = e.id.split('.').map(api.quoteString).join(',');
 		var constructs = e.type.names.map(api.quoteString).join(',');
-		var ctor = 'var $name = $$hxClasses["${e.id}"] = { __ename__: [$ename], __constructs__: [$constructs] }';
-		var fields = [for(c in e.constructors) c.template.execute(name)];
-		
+		var ctor = '$$hxClasses["${e.id}"] = { __ename__: [$ename], __constructs__: [$constructs] }';
+		if (!e.type.isExtern) {
+			ctor = 'var $name = ' + ctor;
+		}
+		var fields = e.type.isExtern ? [] : [for (c in e.constructors) c.template.execute(name)];
+		var exports = 'exports.default = ' + (e.type.isExtern ? e.id : name) + ';';
+
 		return Some([
 			'// Enum: ${e.id}',
 			'var $$global = typeof window != "undefined" ? window : typeof global != "undefined" ? global : typeof self != "undefined" ? self : this',
@@ -45,7 +49,7 @@ class EnumGenerator implements IEnumGenerator {
 			'// Definition',
 			ctor,
 			fields.join('\n'),
-			'exports.default = $name;',
+			exports,
 		].join('\n\n'));
 	}
 }

--- a/src/genjs/generator/hxextern/HxExternClassGenerator.hx
+++ b/src/genjs/generator/hxextern/HxExternClassGenerator.hx
@@ -72,6 +72,20 @@ class HxExternClassGenerator implements IClassGenerator {
 		var imports = new HxExternRequireGenerator().generate(api, filepath.directory(), c.dependencies);
 		
 		var require = '@:jsRequire("' + c.id.split (".").join ("/") + '", "default")';
+		
+		// generate conditional @:native metadata
+		switch haxe.macro.Context.definedValue('global_flag') {
+			case null: // do nothing
+			case global:
+				require = [
+					'#if $global',
+					'@:native("${c.id}")',
+					'#else',
+					require,
+					'#end'
+				].join('\n');
+		}
+		
 		//var classStart = "extern class " + c.id.split (".").pop () + (c.type.superClass != null ? " extends " + c.type.superClass.t.get ().name : "") + " {";
 		var className = c.id.split (".").pop ();
 		var superClassName = null;

--- a/src/stub/estr_stub.js
+++ b/src/stub/estr_stub.js
@@ -3,5 +3,5 @@ Object.defineProperty(exports, "__esModule", {value: true});
 var js_Boot = require('./js/Boot');
 
 exports.default = function $estr() {
-	return js_Boot["__string_rec"](this, '');
+	return js_Boot.default["__string_rec"](this, '');
 }


### PR DESCRIPTION
The first change is that constructors for the externs should be exported differently (for example PIXI.SHAPES would become something like this:
`$hxClasses["PIXI.SHAPES"] = { __ename__: ["PIXI","SHAPES"], __constructs__: ["POLY","RECT","CIRC","ELIP","RREC"] }

exports.default = PIXI.SHAPES;`

Everything works for me, please check if you see something that isn't ok.